### PR TITLE
Added console toggle on run and submit from editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,11 @@ To see full configuration types see [template.lua](./lua/leetcode/config/templat
     ---@type boolean
     logging = true,
 
-    ---@type boolean
-    toggle_console_on_run = false,
-
-    ---@type boolean
     toggle_console_on_submit = false,
 
     console = {
+        ---@type boolean
+        open_on_runcode = false,
         size = {
             width = "75%", ---@type string | integer
             height = "75%", ---@type string | integer

--- a/README.md
+++ b/README.md
@@ -101,8 +101,6 @@ To see full configuration types see [template.lua](./lua/leetcode/config/templat
     ---@type boolean
     logging = true,
 
-    toggle_console_on_submit = false,
-
     console = {
         ---@type boolean
         open_on_runcode = false,
@@ -178,6 +176,7 @@ Console appearance
 
 ```lua
 console = {
+    open_on_runcode = false,
     size = {
         width = "75%", ---@type string | integer
         height = "75%", ---@type string | integer

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ To see full configuration types see [template.lua](./lua/leetcode/config/templat
     ---@type boolean
     logging = true,
 
+    ---@type boolean
+    toggle_console_on_run = false,
+
+    ---@type boolean
+    toggle_console_on_submit = false,
+
     console = {
         size = {
             width = "75%", ---@type string | integer

--- a/lua/leetcode/command.lua
+++ b/lua/leetcode/command.lua
@@ -114,14 +114,12 @@ function cmd.q_run()
     local q = _Lc_questions[_Lc_curr_question]
     if not q then return log.warn("No current question found") end
     q.console:run()
-    if require("leetcode.config").toggle_console_on_run then q.console:toggle() end
 end
 
 function cmd.q_submit()
     local q = _Lc_questions[_Lc_curr_question]
     if not q then return log.warn("No current question found") end
     q.console:submit()
-    if require("leetcode.config").toggle_console_on_submit then q.console:toggle() end
 end
 
 return cmd

--- a/lua/leetcode/command.lua
+++ b/lua/leetcode/command.lua
@@ -114,12 +114,14 @@ function cmd.q_run()
     local q = _Lc_questions[_Lc_curr_question]
     if not q then return log.warn("No current question found") end
     q.console:run()
+    if require("leetcode.config").toggle_console_on_run then q.console:toggle() end
 end
 
 function cmd.q_submit()
     local q = _Lc_questions[_Lc_curr_question]
     if not q then return log.warn("No current question found") end
     q.console:submit()
+    if require("leetcode.config").toggle_console_on_submit then q.console:toggle() end
 end
 
 return cmd

--- a/lua/leetcode/config/init.lua
+++ b/lua/leetcode/config/init.lua
@@ -10,7 +10,7 @@ local config = {
     debug = false,
     lang = "cpp",
     toggle_console_on_run = false,
-    toggle_console_on_submit = false,
+    toggle_console_on_submit = false
 }
 
 ---@class lc.UserAuth

--- a/lua/leetcode/config/init.lua
+++ b/lua/leetcode/config/init.lua
@@ -9,8 +9,6 @@ local config = {
     domain = "https://leetcode.com",
     debug = false,
     lang = "cpp",
-    toggle_console_on_run = false,
-    toggle_console_on_submit = false,
     home = {}, ---@type Path
 }
 
@@ -26,8 +24,6 @@ config.auth = {}
 ---@param cfg lc.UserConfig Configurations to be merged.
 function config.apply(cfg)
     config.user = vim.tbl_deep_extend("force", config.default, cfg)
-    config.toggle_console_on_run = config.user.toggle_console_on_run or false
-    config.toggle_console_on_submit = config.user.toggle_console_on_submit or false
     config.debug = config.user.debug or false
 
     config.debug = config.user.debug or false ---@diagnostic disable-line

--- a/lua/leetcode/config/init.lua
+++ b/lua/leetcode/config/init.lua
@@ -10,7 +10,7 @@ local config = {
     debug = false,
     lang = "cpp",
     toggle_console_on_run = false,
-    toggle_console_on_submit = false
+    toggle_console_on_submit = false,
 }
 
 ---@class lc.UserAuth

--- a/lua/leetcode/config/init.lua
+++ b/lua/leetcode/config/init.lua
@@ -9,6 +9,8 @@ local config = {
     domain = "https://leetcode.com",
     debug = false,
     lang = "cpp",
+    toggle_console_on_run = false,
+    toggle_console_on_submit = false
 }
 
 ---@class lc.UserAuth
@@ -25,7 +27,8 @@ function config.apply(cfg)
     local path = require("plenary.path")
 
     config.user = vim.tbl_deep_extend("force", config.default, cfg)
-
+    config.toggle_console_on_run = config.user.toggle_console_on_run or false
+    config.toggle_console_on_submit = config.user.toggle_console_on_submit or false
     config.debug = config.user.debug or false
     config.domain = "https://leetcode." .. config.user.domain
     config.lang = config.user.lang

--- a/lua/leetcode/config/template.lua
+++ b/lua/leetcode/config/template.lua
@@ -49,13 +49,16 @@ local M = {
     ---@type boolean
     logging = true,
 
-    ---@type boolean
-    toggle_console_on_run = false,
-
-    ---@type boolean
-    toggle_console_on_submit = false,
+    -- ---@type boolean
+    -- toggle_console_on_run = false,
+    --
+    -- ---@type boolean
+    -- toggle_console_on_submit = false,
 
     console = {
+        ---@type boolean
+        open_on_runcode = false,
+
         size = {
             width = "75%", ---@type string | integer
             height = "75%", ---@type string | integer

--- a/lua/leetcode/config/template.lua
+++ b/lua/leetcode/config/template.lua
@@ -49,6 +49,12 @@ local M = {
     ---@type boolean
     logging = true,
 
+    ---@type boolean
+    toggle_console_on_run = false,
+
+    ---@type boolean
+    toggle_console_on_submit = false,
+
     console = {
         size = {
             width = "75%", ---@type string | integer

--- a/lua/leetcode/config/template.lua
+++ b/lua/leetcode/config/template.lua
@@ -49,12 +49,6 @@ local M = {
     ---@type boolean
     logging = true,
 
-    -- ---@type boolean
-    -- toggle_console_on_run = false,
-    --
-    -- ---@type boolean
-    -- toggle_console_on_submit = false,
-
     console = {
         ---@type boolean
         open_on_runcode = false,

--- a/lua/leetcode/runner/init.lua
+++ b/lua/leetcode/runner/init.lua
@@ -31,8 +31,8 @@ function runner:run(submit)
         interpreter.interpret_solution(question.q.title_slug, body, callback)
     else
         interpreter.submit(question.q.title_slug, body, callback)
-if require("leetcode.config").user.console.open_on_runcode then question.console:show() end
     end
+    if require("leetcode.config").user.console.open_on_runcode then question.console:show() end
 end
 
 ---@private

--- a/lua/leetcode/runner/init.lua
+++ b/lua/leetcode/runner/init.lua
@@ -31,6 +31,7 @@ function runner:run(submit)
         interpreter.interpret_solution(question.q.title_slug, body, callback)
     else
         interpreter.submit(question.q.title_slug, body, callback)
+if require("leetcode.config").user.console.open_on_runcode then question.console:show() end
     end
 end
 


### PR DESCRIPTION
Added functionality to toggle console on `LcRun` and `LcSubmit`
I've set toggling console on run/submit to be false by default to stay true to plugins original idea. 
Tried to do this with as few edits as possible. Please let me know if I should change anything, and hopefully it's up to standard. Thank you!