### PR TITLE
feat: add status filter for random question

### DIFF
--- a/lua/leetcode/command/arguments.lua
+++ b/lua/leetcode/command/arguments.lua
@@ -81,6 +81,7 @@ arguments.list = {
 
 arguments.random = {
     difficulty = { "easy", "medium", "hard" },
+    status = { "ac", "notac", "todo" },
     tags = topics,
 }
 

--- a/lua/leetcode/command/init.lua
+++ b/lua/leetcode/command/init.lua
@@ -137,6 +137,13 @@ function cmd.random_question(opts)
     local question = require("leetcode.api.question")
 
     if opts and opts.difficulty then opts.difficulty = opts.difficulty[1]:upper() end
+    if opts and opts.status then
+        opts.status = ({
+            ac = "AC",
+            notac = "TRIED",
+            todo = "NOT_STARTED",
+        })[opts.status[1]]
+    end
 
     local q, err = question.random(opts)
     if err then return log.err(err) end


### PR DESCRIPTION
Hello, I hope you're doing well.

I'd like to make a small modification so that users can receive random questions based on question's status, whether it's ac (Accepted), notac (Not Accepted), or todo (To-Do). This feature can be beneficial for users who specifically want to access new questions or practice previously solved ones.