### PR TITLE
fix: rust-tools.nvim not found

### DIFF
--- a/lua/leetcode-ui/question.lua
+++ b/lua/leetcode-ui/question.lua
@@ -91,7 +91,16 @@ function Question:handle_mount()
     vim.cmd("$tabe " .. self.file:absolute())
 
     -- https://github.com/kawre/leetcode.nvim/issues/14
-    if self.lang == "rust" then pcall(require("rust-tools.standalone").start_standalone_client) end
+    if self.lang == "rust" then
+        local ok, tool = pcall(require, "rust-tools.standalone")
+        if not ok then
+            if not pcall(require, "rustaceanvim") then
+                log.warn("Plugin rust-tool.nvim either rustaceanvim for rust not found.")
+            end
+        else
+            pcall(tool.start_standalone_client)
+        end
+    end
 
     self.bufnr = vim.api.nvim_get_current_buf()
     self.winid = vim.api.nvim_get_current_win()

--- a/lua/leetcode-ui/question.lua
+++ b/lua/leetcode-ui/question.lua
@@ -92,14 +92,7 @@ function Question:handle_mount()
 
     -- https://github.com/kawre/leetcode.nvim/issues/14
     if self.lang == "rust" then
-        local ok, tool = pcall(require, "rust-tools.standalone")
-        if not ok then
-            if not pcall(require, "rustaceanvim") then
-                log.warn("Plugin rust-tool.nvim either rustaceanvim for rust not found.")
-            end
-        else
-            pcall(tool.start_standalone_client)
-        end
+        pcall(function() require("rust-tools.standalone").start_standalone_client() end)
     end
 
     self.bufnr = vim.api.nvim_get_current_buf()


### PR DESCRIPTION
I updated my rust lsp config recently.I just migrated from rust-tools.nvim to rustaceanvim manually. 
When I open my neovim with `nvim leetcode.nvim`, and pick a problem with rust, sth wrong. 
So I made this PR for fix it. :D.
