### PR TITLE
fix: image display problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ https://github.com/kawre/leetcode.nvim/assets/69250723/aee6584c-e099-4409-b114-1
         "nvim-treesitter/nvim-treesitter",
         "rcarriga/nvim-notify",
         "nvim-tree/nvim-web-devicons",
+        {
+            "3rd/image.nvim",
+            opts = {
+                max_width_window_percentage = 100,
+                window_overlap_clear_enabled = true,
+            }
+        },
     },
     opts = {
         -- configuration goes here

--- a/README.zh.md
+++ b/README.zh.md
@@ -59,6 +59,13 @@ https://github.com/kawre/leetcode.nvim/assets/69250723/aee6584c-e099-4409-b114-1
         "nvim-treesitter/nvim-treesitter",
         "rcarriga/nvim-notify",
         "nvim-tree/nvim-web-devicons",
+        {
+            "3rd/image.nvim",
+            opts = {
+                max_width_window_percentage = 100,
+                window_overlap_clear_enabled = true,
+            }
+        },
     },
     opts = {
         -- 配置放在这里


### PR DESCRIPTION
The default `image.nvim` configuration may cause some image display problems.
I hope the new `image.nvim` configuration can appear in `README.md` to prevent others from encountering the same problem as me.

## 1. too wide images
### problem
![too-wide-images-problem](https://github.com/kawre/leetcode.nvim/assets/74849775/d280a694-430f-4920-8475-b6509eb2f1bd)

The default value is `max_width_window_percentage = nil`.
It will cause the the image to cross from the description area to the code area.

### solve
To solve this just set `max_width_window_percentage = 100`.

![too-wide-images-solve](https://github.com/kawre/leetcode.nvim/assets/74849775/c28e83cb-72a8-424b-8bd1-1161693bbede)

## 2. image overlaps the console area
### problem
![image-overlap-problem](https://github.com/kawre/leetcode.nvim/assets/74849775/ed776cec-ce4d-43ac-96f9-daac5a562cb6)

Image will overlaps the console area. #23 also has the same problem.

### solve
To solve this just set `window_overlap_clear_enabled = true`.

![image-overlap-solve](https://github.com/kawre/leetcode.nvim/assets/74849775/89f61d5c-93c8-43ae-a977-d0773d4bb706)
