### PR TITLE
Fix: Detach open command execution

### DIFF
--- a/lua/leetcode/command/init.lua
+++ b/lua/leetcode/command/init.lua
@@ -313,7 +313,7 @@ function cmd.open()
             command = string.format("start \"\" \"%s\"", q.cache.link)
         end
 
-        os.execute(command)
+        vim.fn.jobstart(command, { detach = true })
     end
 end
 


### PR DESCRIPTION
This commit simply switches `os.execute` with `vim.fn.jobstart` with `detach` set to `true`, making the editor available after opening the problems' url allowing you to edit, while the browser is running.

The `detach` option keeps the browser open after the editor shuts down. It is not the default behavior (which would make the browser shut down with the editor, I find the introduced behavior to be more appropriate).

NOTE: This commit has been tested only on Linux; but I don't suppose there would be any meaningful difference.