### PR TITLE
fix: remove nvim-treesitter dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ https://github.com/kawre/leetcode.nvim/assets/69250723/aee6584c-e099-4409-b114-1
 
 - [nui.nvim]
 
-- [nvim-treesitter] _**(optional, but highly recommended)**_
+- [tree-sitter-html] _**(optional, but highly recommended)**_
   used for formatting the question description.
-  Make sure to install the parser for `html`.
+  Can be installed with [nvim-treesitter].
 
 - [nvim-notify] _**(optional)**_
 
@@ -497,3 +497,4 @@ You can then exit [leetcode.nvim] using `:Leet exit` command
 [nvim-treesitter]: https://github.com/nvim-treesitter/nvim-treesitter
 [nvim-web-devicons]: https://github.com/nvim-tree/nvim-web-devicons
 [telescope.nvim]: https://github.com/nvim-telescope/telescope.nvim
+[tree-sitter-html]: https://github.com/tree-sitter/tree-sitter-html

--- a/lua/leetcode/parser/init.lua
+++ b/lua/leetcode/parser/init.lua
@@ -10,12 +10,7 @@ local Parser = Object("LeetParser")
 ---@param text string
 ---@return lc.ui.Group
 function Parser.static:parse(text)
-    local check_for_html = function()
-        local parsers = require("nvim-treesitter.parsers")
-        assert(parsers.get_parser_configs()["html"])
-    end
-
-    if pcall(check_for_html) then
+    if #vim.api.nvim_get_runtime_file("parser/html.so", true) > 0 then
         return Tag:parse(text)
     else
         return Plain:parse(text)


### PR DESCRIPTION
This plugin actually uses Neovim's core API and doesn't depend on nvim-treesitter's legacy API (which will be removed).

I have

- Replaced the only place where nvim-treesitter is needed to use Neovim's core API to check for a parser on the runtimepath.
- Updated the reamde to clarify that this plugin doesn't depend on nvim-treesitter (there are multiple ways to install parsers).