### PR TITLE
fix: provide an option for not showing the expired window when gettin…

### DIFF
--- a/lua/leetcode/api/utils.lua
+++ b/lua/leetcode/api/utils.lua
@@ -151,7 +151,7 @@ function utils.check_err(err)
     end
 
     if err.status then
-        if err.status == 401 or err.status == 403 then
+        if (err.status == 401 or err.status == 403) and config.user.show_menu_when_expire then
             require("leetcode.command").expire()
             err.msg = "Session expired? Enter a new cookie to keep using `leetcode.nvim`"
         end

--- a/lua/leetcode/config/template.lua
+++ b/lua/leetcode/config/template.lua
@@ -127,6 +127,9 @@ local M = {
 
     ---@type boolean
     image_support = false,
+
+    ---@type boolean
+    show_menu_when_expire = false,
 }
 
 return M


### PR DESCRIPTION
…g 401/403

This is a suggested temprary fix for http 401/403 error from leetcode.

I found that the current leetcode api only reject some of the requests. It's often the case that leetcode returns 403 for some requests but still accept some other requests after that. Treating all the 403 requests as expired just made the entire plugin unusable.

I added and `show_menu_when_expire` option to the config template. When setting this flag to false, the system will only pop an error instead of call the `cmd.menu()` and `cmd.cookie_prompt()` to send the user all the way back to the main menu.

![image](https://github.com/kawre/leetcode.nvim/assets/79500078/68c91058-ca27-4057-b1ac-c4808e2190a0)

I suspect that most of the 403 we got recently is because of the change of leetcode api. I think reseving this option is also important for leetcode.nvim to handle future api change. Otherwise, a simple api change may disbale the entire plugin.