### PR TITLE
Fix todo status handling

### DIFF
--- a/lua/leetcode/api/utils.lua
+++ b/lua/leetcode/api/utils.lua
@@ -212,7 +212,7 @@ function utils.normalize_problems(problems)
 
     return vim.tbl_map(function(p)
         return {
-            status = p.status,
+            status = p.status == vim.NIL and "todo" or p.status, -- api returns nil for todo
             id = p.stat.question_id,
             frontend_id = p.stat.frontend_question_id,
             title = p.stat.question__title,

--- a/lua/leetcode/config/icons.lua
+++ b/lua/leetcode/config/icons.lua
@@ -19,7 +19,7 @@ icons.hl = {
     status = {
         ac = { icons.status.ac, "leetcode_easy" },
         notac = { icons.status.notac, "leetcode_medium" },
-        todo = { icons.status.todo, "leetcode_alt" },
+        -- todo = { icons.status.todo, "leetcode_alt" },
     },
     lock = { icons.lock, "leetcode_medium" },
     unlock = { icons.unlock, "leetcode_medium" },

--- a/lua/leetcode/pickers/question.lua
+++ b/lua/leetcode/pickers/question.lua
@@ -38,9 +38,6 @@ local function display_user_status(question)
         return config.auth.is_premium and config.icons.hl.unlock or config.icons.hl.lock
     end
 
-    if question.status == vim.NIL then
-        return { "" }
-    end
     return config.icons.hl.status[question.status] or { "" }
 end
 


### PR DESCRIPTION
For `todo` status api return vim.NIL, normalize it into "todo".

Fixes #105 

Now `Leet list status=todo` produces valid results.