### PR TITLE
fix: Remove s when it's 1 problem solved

### DIFF
--- a/lua/leetcode-ui/popup/languages.lua
+++ b/lua/leetcode-ui/popup/languages.lua
@@ -29,11 +29,7 @@ function Languages:handle(res)
 
     if config.translator then
         lines:append("解题数", "leetcode_alt")
-        if res.problems_solved == 1 then
-            lines:append(" problem solved", "leetcode_alt")
-        else
-            lines:append(" problems solved", "leetcode_alt")
-        end
+        lines:append(" " .. res.problems_solved)
     else
         lines:append("" .. res.problems_solved)
         if res.problems_solved == 1 then

--- a/lua/leetcode-ui/popup/languages.lua
+++ b/lua/leetcode-ui/popup/languages.lua
@@ -29,10 +29,18 @@ function Languages:handle(res)
 
     if config.translator then
         lines:append("解题数", "leetcode_alt")
-        lines:append(" " .. res.problems_solved)
+        if res.problems_solved == 1 then
+            lines:append(" problem solved", "leetcode_alt")
+        else
+            lines:append(" problems solved", "leetcode_alt")
+        end
     else
         lines:append("" .. res.problems_solved)
-        lines:append(" problems solved", "leetcode_alt")
+        if res.problems_solved == 1 then
+            lines:append(" problem solved", "leetcode_alt")
+        else
+            lines:append(" problems solved", "leetcode_alt")
+        end
     end
 
     return lines


### PR DESCRIPTION
In Menu > Statistics > Languages, if you solved 1 problem with a language, it'll write "1 problems solved".
I changed it to "1 problem solved".
Nothing fancy, but a correction is a fix :D
![result](https://github.com/user-attachments/assets/5e710ceb-271d-403f-9453-b3f4ae06b87e)

