### PR TITLE
Support custom filename formatting

### DIFF
--- a/lua/leetcode-ui/question.lua
+++ b/lua/leetcode-ui/question.lua
@@ -63,6 +63,27 @@ function Question:path()
     local lang = utils.get_lang(self.lang)
     local alt = lang.alt and ("." .. lang.alt) or ""
 
+    local fn_user_format = config.storage.format
+    if type(fn_user_format) == "function" then
+        local format_opts = {
+            id = "" .. self.q.frontend_id,
+            slug = self.q.title_slug,
+            ft_alt = alt,
+            ft = lang.ft,
+        }
+        local fn_user = fn_user_format(format_opts)
+        if type(fn_user) == "string" and #fn_user > 0 then
+            self.file = config.storage.home:joinpath(fn_user)
+            local existed = self.file:exists()
+
+            if not existed then
+                self.file:write(self:snippet(), "w")
+            end
+
+            return self.file:absolute(), existed
+        end
+    end
+
     -- handle legacy file names first
     local fn_legacy = --
         ("%s.%s-%s.%s"):format(self.q.frontend_id, self.q.title_slug, lang.slug, lang.ft)

--- a/lua/leetcode/config/init.lua
+++ b/lua/leetcode/config/init.lua
@@ -19,7 +19,7 @@ local config = {
     debug = false,
     lang = "cpp",
     version = "1.0.1",
-    storage = {}, ---@type table<string, Path>
+    storage = {}, ---@type lc.storage
     theme = {}, ---@type lc.highlights
     plugins = {},
 
@@ -54,7 +54,8 @@ function config.setup()
         config.user.storage.home = config.user.directory
     end
 
-    config.user.storage = vim.tbl_map(vim.fn.expand, config.user.storage)
+    config.user.storage.home = vim.fn.expand(config.user.storage.home)
+    config.user.storage.cache = vim.fn.expand(config.user.storage.cache)
 
     config.debug = config.user.debug or false ---@diagnostic disable-line
     config.lang = config.user.lang
@@ -64,6 +65,8 @@ function config.setup()
 
     config.storage.cache = P:new(config.user.storage.cache) ---@diagnostic disable-line
     config.storage.cache:mkdir()
+
+    config.storage.format = config.user.storage.format
 
     for _, plug_load_fn in ipairs(lazy_plugs) do
         plug_load_fn()

--- a/lua/leetcode/config/template.lua
+++ b/lua/leetcode/config/template.lua
@@ -36,7 +36,8 @@
 
 ---@alias lc.inject { before?: string|string[], after?: string|string[] }
 
----@alias lc.storage table<"cache"|"home", string>
+---@alias lc.storage.format_opts { id : string, slug : string, ft_alt : string, ft : string }
+---@alias lc.storage { cache: string, home: string, format: fun(opts: lc.storage.format_opts): string | nil }
 
 ---@alias lc.picker { provider?: "fzf-lua" | "telescope" }
 
@@ -58,6 +59,9 @@ local M = {
     storage = {
         home = vim.fn.stdpath("data") .. "/leetcode",
         cache = vim.fn.stdpath("cache") .. "/leetcode",
+        format = function()
+            return nil
+        end,
     },
 
     ---@type table<string, boolean>


### PR DESCRIPTION
This PR adds a way to control the format of the question filenames, by passing a function in your config. Here's a sample config that uses it:

```lua
return {
  "kawre/leetcode.nvim",
  build = ":TSUpdate html", -- if you have `nvim-treesitter` installed
  dependencies = {
    -- "nvim-telescope/telescope.nvim",
    "ibhagwan/fzf-lua",
    "nvim-lua/plenary.nvim",
    "MunifTanjim/nui.nvim",
  },
  opts = {
    lang = "rust",
    storage = {
      home = vim.fn.stdpath("data") .. "/leetcode/src/bin",
      cache = vim.fn.stdpath("cache") .. "/leetcode",
      format = function(opts)
        local fn = ("%s__%s%s.%s"):format(opts.id, opts.slug, opts.ft_alt, opts.ft)
        return fn
      end,
    },
  },
}
```

### Motivation

I wanted to use `src/bin` in a Rust project as a home folder, so that LSP stuff and commands like `cargo fmt` and `cargo test` work smoothly. But I ran into this problem (e.g. running `cargo test`):

```txt
error: invalid character `'.'` in crate name: `9.palindrome-number`
```

So I want the filenames not to include ".".