### PR TITLE
Add in-place question shuffle feature (no more buffer clutter!)

### DIFF
--- a/lua/leetcode-ui/layout/console.lua
+++ b/lua/leetcode-ui/layout/console.lua
@@ -17,11 +17,13 @@ local log = require("leetcode.logger")
 local ConsoleLayout = Layout:extend("LeetConsoleLayout")
 
 function ConsoleLayout:unmount() --
-    ConsoleLayout.super.unmount(self)
-
-    self.testcase = Testcase(self)
-    self.result = Result(self)
-    self.popups = { self.testcase, self.result }
+	if self.testcase and self.testcase.unmount then
+		self.testcase:unmount()
+	end
+	if self.result and self.result.unmount then
+		self.result:unmount()
+	end
+	ConsoleLayout.super.unmount(self)
 end
 
 function ConsoleLayout:hide()

--- a/lua/leetcode-ui/question.lua
+++ b/lua/leetcode-ui/question.lua
@@ -48,66 +48,6 @@ function Question:set_lines(code)
     vim.api.nvim_buf_set_lines(self.bufnr, s_i - 1, e_i, false, vim.split(code, "\n"))
 end
 
-function Question:shuffle()
-    local api_question = require("leetcode.api.question")
-    local problems = require("leetcode.cache.problemlist")
-
-    -- Fetch a new random question (minimal info)
-    local q, err = api_question.random()
-    if err then
-        log.err(err)
-        return
-    end
-
-    -- Get full question info by title_slug
-    local full_q = api_question.by_title_slug(q.title_slug)
-    if not full_q then
-        log.err("Failed to fetch full question info for: " .. (q.title_slug or "nil"))
-        return
-    end
-
-    -- Update self fields
-    self.q = full_q
-    self.cache = problems.get_by_title_slug(q.title_slug) or {}
-
-    -- Overwrite buffer contents
-    self:set_lines(self:snippet(true))
-
-    -- (Optionally update info, description, etc. if needed)
-    if self.description and self.description.update then
-        self.description:update(self)
-    end
-    if self.info and self.info.update then
-        self.info:update(self)
-    end
-    if self.console and self.console.update then
-        self.console:update(self)
-    end
-
-    log.info("Shuffled to a new random question: " .. (full_q.title or q.title_slug or "unknown"))
-end
-    -- Update self fields
-    self.q = q
-    self.cache = problems.get_by_title_slug(q.title_slug) or {}
-
-    -- Overwrite buffer contents
-    self:set_lines(self:snippet(true))
-
-    -- (Optionally update info, description, etc. if needed)
-    if self.description and self.description.update then
-        self.description:update(self)
-    end
-    if self.info and self.info.update then
-        self.info:update(self)
-    end
-    if self.console and self.console.update then
-        self.console:update(self)
-    end
-
-    log.info("Shuffled to a new random question: " .. q.title)
-end
-
-
 function Question:reset_lines()
     local new_lines = self:snippet(true) or ""
 
@@ -378,6 +318,47 @@ function Question:init(problem)
     self.cache = problem
     self.lang = config.lang
 end
+
+function Question:shuffle()
+    local api_question = require("leetcode.api.question")
+    local problems = require("leetcode.cache.problemlist")
+
+    -- Fetch a new random question (minimal info)
+    local q, err = api_question.random()
+    if err then
+        log.err(err)
+        return
+    end
+
+    -- Get full question info by title_slug
+    local full_q = api_question.by_title_slug(q.title_slug)
+    if not full_q then
+        log.err("Failed to fetch full question info for: " .. (q.title_slug or "nil"))
+        return
+    end
+
+    -- Update self fields
+    self.q = full_q
+    self.cache = problems.get_by_title_slug(q.title_slug) or {}
+
+    -- Overwrite buffer contents
+    self:set_lines(self:snippet(true))
+
+    -- (Optionally update info, description, etc. if needed)
+    if self.description and self.description.update then
+        self.description:update(self)
+    end
+    if self.info and self.info.update then
+        self.info:update(self)
+    end
+    if self.console and self.console.update then
+        self.console:update(self)
+    end
+
+    log.info("Shuffled to a new random question: " .. (full_q.title or q.title_slug or "unknown"))
+end
+
+
 
 ---@type fun(question: lc.cache.Question): lc.ui.Question
 local LeetQuestion = Question

--- a/lua/leetcode-ui/question.lua
+++ b/lua/leetcode-ui/question.lua
@@ -497,6 +497,12 @@ function Question:shuffle()
     self.console = Console(self)
     self.info = Info(self)
 
+    -- HACK: Force LSP client to re-attach to the buffer after renaming it.
+    -- This prevents errors like "trying to get AST for non-added document".
+    if #vim.lsp.get_active_clients({ bufnr = self.bufnr }) > 0 then
+        vim.cmd.doautocmd("BufRead")
+    end
+
     log.info("Shuffled to a new random question: " .. (full_q.title or q.title_slug or "unknown"))
 end
 

--- a/lua/leetcode-ui/question.lua
+++ b/lua/leetcode-ui/question.lua
@@ -52,13 +52,40 @@ function Question:shuffle()
     local api_question = require("leetcode.api.question")
     local problems = require("leetcode.cache.problemlist")
 
-    -- Fetch a new random question
+    -- Fetch a new random question (minimal info)
     local q, err = api_question.random()
     if err then
         log.err(err)
         return
     end
 
+    -- Get full question info by title_slug
+    local full_q = api_question.by_title_slug(q.title_slug)
+    if not full_q then
+        log.err("Failed to fetch full question info for: " .. (q.title_slug or "nil"))
+        return
+    end
+
+    -- Update self fields
+    self.q = full_q
+    self.cache = problems.get_by_title_slug(q.title_slug) or {}
+
+    -- Overwrite buffer contents
+    self:set_lines(self:snippet(true))
+
+    -- (Optionally update info, description, etc. if needed)
+    if self.description and self.description.update then
+        self.description:update(self)
+    end
+    if self.info and self.info.update then
+        self.info:update(self)
+    end
+    if self.console and self.console.update then
+        self.console:update(self)
+    end
+
+    log.info("Shuffled to a new random question: " .. (full_q.title or q.title_slug or "unknown"))
+end
     -- Update self fields
     self.q = q
     self.cache = problems.get_by_title_slug(q.title_slug) or {}

--- a/lua/leetcode-ui/question.lua
+++ b/lua/leetcode-ui/question.lua
@@ -319,6 +319,8 @@ function Question:init(problem)
     self.lang = config.lang
 end
 
+-- start of shuffle functionality.
+
 function Question:shuffle()
     local api_question = require("leetcode.api.question")
     local problems = require("leetcode.cache.problemlist")
@@ -344,21 +346,23 @@ function Question:shuffle()
     -- Overwrite buffer contents
     self:set_lines(self:snippet(true))
 
-    -- (Optionally update info, description, etc. if needed)
-    if self.description and self.description.update then
-        self.description:update(self)
-    end
-    if self.info and self.info.update then
-        self.info:update(self)
-    end
-    if self.console and self.console.update then
-        self.console:update(self)
-    end
+    -- Unmount and remount description, info, console
+    if self.description and self.description.unmount then self.description:unmount() end
+    if self.info and self.info.unmount then self.info:unmount() end
+    if self.console and self.console.unmount then self.console:unmount() end
+
+    -- Recreate description, info, console for the new question
+    local Description = require("leetcode-ui.split.description")
+    local Console = require("leetcode-ui.layout.console")
+    local Info = require("leetcode-ui.popup.info")
+    self.description = Description(self):mount()
+    self.console = Console(self)
+    self.info = Info(self)
 
     log.info("Shuffled to a new random question: " .. (full_q.title or q.title_slug or "unknown"))
 end
 
-
+-- end of shuffle functionality.
 
 ---@type fun(question: lc.cache.Question): lc.ui.Question
 local LeetQuestion = Question

--- a/lua/leetcode-ui/question.lua
+++ b/lua/leetcode-ui/question.lua
@@ -48,6 +48,39 @@ function Question:set_lines(code)
     vim.api.nvim_buf_set_lines(self.bufnr, s_i - 1, e_i, false, vim.split(code, "\n"))
 end
 
+function Question:shuffle()
+    local api_question = require("leetcode.api.question")
+    local problems = require("leetcode.cache.problemlist")
+
+    -- Fetch a new random question
+    local q, err = api_question.random()
+    if err then
+        log.err(err)
+        return
+    end
+
+    -- Update self fields
+    self.q = q
+    self.cache = problems.get_by_title_slug(q.title_slug) or {}
+
+    -- Overwrite buffer contents
+    self:set_lines(self:snippet(true))
+
+    -- (Optionally update info, description, etc. if needed)
+    if self.description and self.description.update then
+        self.description:update(self)
+    end
+    if self.info and self.info.update then
+        self.info:update(self)
+    end
+    if self.console and self.console.update then
+        self.console:update(self)
+    end
+
+    log.info("Shuffled to a new random question: " .. q.title)
+end
+
+
 function Question:reset_lines()
     local new_lines = self:snippet(true) or ""
 

--- a/lua/leetcode/command/init.lua
+++ b/lua/leetcode/command/init.lua
@@ -277,6 +277,14 @@ function cmd.q_submit()
     end
 end
 
+function cmd.q_shuffle()
+    local utils = require("leetcode.utils")
+    local q = utils.curr_question()
+    if q then
+        q:shuffle()
+    end
+end
+
 function cmd.ui_skills()
     if config.is_cn then
         return
@@ -611,6 +619,7 @@ cmd.commands = {
     run = { cmd.q_run },
     test = { cmd.q_run },
     submit = { cmd.q_submit },
+    shuffle = { cmd.q_shuffle },
     daily = { cmd.qot },
     yank = { cmd.yank },
     open = { cmd.open },

--- a/lua/leetcode/command/init.lua
+++ b/lua/leetcode/command/init.lua
@@ -603,7 +603,7 @@ function cmd.exec(args)
     end
 
     if cmds and type(cmds[1]) == "function" then
-        cmds1
+        cmds[1](options)
     else
         -- This happens if the command was empty or only contained unknown subcommands
         return log.error(("Invalid command: `:Leet %s`"):format(args.args))


### PR DESCRIPTION
This PR adds a “shuffle” feature to LeetCode.nvim, allowing users to load a new random question in the same buffer, with the question info panel updating as well. Previously, using the random feature would open a new buffer each time, requiring manual cleanup. Now, users can quickly browse random questions—just like the shuffle button on the LeetCode website!

Key changes:

- Adds a shuffle() method to the Question object
- Updates the code and info buffers in-place
- Keymap example: <leader>ls to shuffle in the current question buffer

Benefits:

- Much faster random question browsing
- No buffer clutter

I’d love feedback and am happy to make changes as needed!