### PR TITLE
feat: add Hot 100 study plan picker

### DIFF
--- a/lua/leetcode-plugins/cn/queries.lua
+++ b/lua/leetcode-plugins/cn/queries.lua
@@ -160,3 +160,15 @@ queries.session_progress = [[
             }
         }
     ]]
+
+queries.hot100 = [[
+        query studyPlanV2Detail($planSlug: String!) {
+            studyPlanV2Detail(planSlug: $planSlug) {
+                planSubGroups {
+                    questions {
+                        titleSlug
+                    }
+                }
+            }
+        }
+    ]]

--- a/lua/leetcode-ui/group/page/problems.lua
+++ b/lua/leetcode-ui/group/page/problems.lua
@@ -33,12 +33,19 @@ local daily = Button("Daily", {
     on_press = cmd.qot,
 })
 
+local hot100 = Button("Hot 100", {
+    icon = "󱐋",
+    sc = "h",
+    on_press = cmd.hot100,
+})
+
 local back = BackButton("menu")
 
 page:insert(Buttons({
     list,
     random,
     daily,
+    hot100,
     back,
 }))
 

--- a/lua/leetcode/api/problems.lua
+++ b/lua/leetcode/api/problems.lua
@@ -108,6 +108,29 @@ function Problems.question_of_today(cb)
     })
 end
 
+---@param cb function
+function Problems.hot100(cb)
+    local query = queries.hot100
+    local variables = { planSlug = "top-100-liked" }
+
+    utils.query(query, variables, {
+        callback = function(res, err)
+            if err then
+                return cb(nil, err)
+            end
+
+            local groups = res.data.studyPlanV2Detail.planSubGroups
+            local questions = {}
+            for _, group in ipairs(groups) do
+                for _, q in ipairs(group.questions) do
+                    table.insert(questions, q)
+                end
+            end
+            cb(questions)
+        end,
+    })
+end
+
 function Problems.translated_titles(cb)
     local query = queries.translations
 

--- a/lua/leetcode/api/queries.lua
+++ b/lua/leetcode/api/queries.lua
@@ -179,4 +179,16 @@ queries.session_progress = [[
         }
     ]]
 
+queries.hot100 = [[
+        query studyPlanV2Detail($planSlug: String!) {
+            studyPlanV2Detail(planSlug: $planSlug) {
+                planSubGroups {
+                    questions {
+                        titleSlug
+                    }
+                }
+            }
+        }
+    ]]
+
 return queries

--- a/lua/leetcode/command/init.lua
+++ b/lua/leetcode/command/init.lua
@@ -168,6 +168,36 @@ function cmd.random_question(opts)
     Question(item):mount()
 end
 
+function cmd.hot100()
+    require("leetcode.utils").auth_guard()
+
+    local problems_api = require("leetcode.api.problems")
+    local problemlist = require("leetcode.cache.problemlist")
+    local picker = require("leetcode.picker")
+
+    problems_api.hot100(function(questions, err)
+        if err then
+            return log.err(err)
+        end
+
+        local slug_order = {}
+        for i, q in ipairs(questions) do
+            slug_order[q.titleSlug] = i
+        end
+
+        local cached = problemlist.get()
+        local questions = vim.tbl_filter(function(q)
+            return slug_order[q.title_slug] ~= nil
+        end, cached)
+
+        table.sort(questions, function(a, b)
+            return slug_order[a.title_slug] < slug_order[b.title_slug]
+        end)
+
+        picker.question(questions, {})
+    end)
+end
+
 function cmd.start_with_cmd()
     local leetcode = require("leetcode")
     if leetcode.start(false) then
@@ -630,6 +660,7 @@ cmd.commands = {
     --     },
     --     update = { cmd.update_sessions },
     -- },
+    hot100 = { cmd.hot100 },
     list = {
         cmd.problems,
         _args = arguments.list,


### PR DESCRIPTION
## Summary

- Add `studyPlanV2Detail` GraphQL query to fetch the [Hot 100](https://leetcode.com/studyplan/top-100-liked/) study plan questions
- Add `Problems.hot100()` API function (supports both `leetcode.com` and `leetcode.cn`)
- Add `cmd.hot100` command that cross-references the plan with local cache and opens the picker sorted in Hot 100 order
- Add **Hot 100** button (shortcut `h`) to the Problems menu page
- Register `:Leet hot100` user command

## Usage

From the menu: **Problems → h (Hot 100)**

Or directly: `:Leet hot100`

## Test plan

- [ ] `:Leet hot100` opens picker with exactly the Hot 100 problems in correct order
- [ ] Problems menu shows Hot 100 button with `h` shortcut
- [ ] Solved/todo status is correctly reflected from local cache
- [ ] Works on both `leetcode.com` and `leetcode.cn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)