### PR TITLE
fix: don't schedule message if not in fast event

### DIFF
--- a/lua/leetcode/logger/init.lua
+++ b/lua/leetcode/logger/init.lua
@@ -29,6 +29,10 @@ function logger.log(msg, lvl)
         msg = debug.traceback(msg .. "\n")
     end
 
+    if not vim.in_fast_event() then
+        vim.notify(msg, lvl, { title = title })
+        return
+    end
     vim.schedule(function()
         vim.notify(msg, lvl, { title = title })
     end)


### PR DESCRIPTION
It's harmless

The motivation is to `:silent!` the log print when writing some snippets
