### PR TITLE
fix(imports): use clangd-friendly cpp imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ injector = { ---@type table<lc.lang, lc.inject>
     ["cpp"] = {
         imports = function()
             -- return a different list to omit default imports
-            return { "#include <bits/stdc++.h>", "using namespace std;" }
+            return { "#include <vector> // IWYU pragma: keep", "using namespace std;" }
         end,
         after = "int main() {}",
     },

--- a/lua/leetcode/config/imports.lua
+++ b/lua/leetcode/config/imports.lua
@@ -73,7 +73,28 @@ imports["java"] = {
 }
 
 imports["cpp"] = {
-    "#include <bits/stdc++.h>",
+    "#include <algorithm> // IWYU pragma: keep",
+    "#include <array> // IWYU pragma: keep",
+    "#include <bitset> // IWYU pragma: keep",
+    "#include <climits> // IWYU pragma: keep",
+    "#include <cmath> // IWYU pragma: keep",
+    "#include <cstdint> // IWYU pragma: keep",
+    "#include <deque> // IWYU pragma: keep",
+    "#include <functional> // IWYU pragma: keep",
+    "#include <iostream> // IWYU pragma: keep",
+    "#include <limits> // IWYU pragma: keep",
+    "#include <list> // IWYU pragma: keep",
+    "#include <map> // IWYU pragma: keep",
+    "#include <numeric> // IWYU pragma: keep",
+    "#include <queue> // IWYU pragma: keep",
+    "#include <set> // IWYU pragma: keep",
+    "#include <stack> // IWYU pragma: keep",
+    "#include <string> // IWYU pragma: keep",
+    "#include <tuple> // IWYU pragma: keep",
+    "#include <unordered_map> // IWYU pragma: keep",
+    "#include <unordered_set> // IWYU pragma: keep",
+    "#include <utility> // IWYU pragma: keep",
+    "#include <vector> // IWYU pragma: keep",
     "using namespace std;",
 }
 


### PR DESCRIPTION
## Summary

- replace the default C++ `bits/stdc++.h` import with standard library headers
- add `IWYU pragma: keep` to avoid clangd unused include diagnostics
- update the injector example in README

## Motivation

This follows up on #216.

`bits/stdc++.h` is a GCC-specific header. On macOS, Apple clangd reports it as missing, which also breaks common completions and diagnostics for symbols like `vector`.

Since injected imports are editor-only and not submitted, using standard headers makes the default C++ editing experience more portable.

Tested locally with clangd: diagnostics are clean.