### PR TITLE
fix(parser): escape raw less-than characters

### DIFF
--- a/lua/leetcode-plugins/cn/normalizer.lua
+++ b/lua/leetcode-plugins/cn/normalizer.lua
@@ -9,6 +9,7 @@ function Normalizer:cleanup()
         :gsub("<br%s*/>", "\n")
         :gsub("<meta[^>]*/>", "")
         :gsub("&nbsp;", " ")
+        :gsub("<([^/%a!])", "&lt;%1")
         :gsub("<(/?)b>", "<%1strong>")
         :gsub(":", "：")
 end

--- a/lua/leetcode/parser/normalizer.lua
+++ b/lua/leetcode/parser/normalizer.lua
@@ -14,6 +14,7 @@ function Normalizer:cleanup() --
         :gsub("<br%s*/>", "\n")
         :gsub("<meta[^>]*/>", "")
         :gsub("&nbsp;", " ")
+        :gsub("<([^/%a!])", "&lt;%1")
         -- :gsub("<(/?)b([^>]*)>", "<%1strong%2>")
         :gsub("<(/?)b>", "<%1strong>")
     -- :gsub("&#?%w+;", function(e) --


### PR DESCRIPTION
## Summary

Fix rendering of raw less-than characters in problem descriptions.

Some problem descriptions include inline code like `<code>k < 0</code>`. The raw `<` can be parsed as the start of an HTML tag, causing the rendered description to drop the `< 0` part.

This escapes raw less-than characters before HTML parsing in both the default and CN normalizers.

## Verification

- Verified default parser renders `<code>k < 0</code>` as `k < 0`
- Verified CN parser renders `<code>k < 0</code>` as `k < 0`